### PR TITLE
Add a new example to rsync.

### DIFF
--- a/pages/rsync.tldr
+++ b/pages/rsync.tldr
@@ -37,5 +37,14 @@ Transfer a directory and all its children from a remote to local.
 rsync\ \-r\ mike\@devbox:~/projects/cakeStore\ /Users/mike/devProjects/
 \f[]
 .fi
+.PP
+Transfer a directory and all its children from a remote to local, with
+compression enabled, while the remote uses a non\-standard port 30
+.IP
+.nf
+\f[C]
+rsync\ \-zr\ \-e\ \[aq]ssh\ \-p\ 30\[aq]\ mike\@devbox:~/projects/cakeStore\ /Users/mike/devProjects/
+\f[]
+.fi
 .SH AUTHORS
 andrewboerema, John Wu, Boris Egorov.

--- a/src/rsync.md
+++ b/src/rsync.md
@@ -24,3 +24,9 @@ Transfer all \*.js files in current directory to host 'devbox' as user 'mike'.
 Transfer a directory and all its children from a remote to local.
 
     rsync -r mike@devbox:~/projects/cakeStore /Users/mike/devProjects/
+
+Transfer a directory and all its children from a remote to local, with compression enabled, while the remote uses a non-standard port 30
+
+    rsync -zr -e 'ssh -p 30' mike@devbox:~/projects/cakeStore /Users/mike/devProjects/
+
+    


### PR DESCRIPTION
Add an example for `rsync`.

The example shows how to use the compression switch (`-z`) and specify
a non-standard port (other than 22) with the `-e` switch.

The tldr page is also updated accordingly.
